### PR TITLE
Fixed key names in localStoage iterator

### DIFF
--- a/src/persist.js
+++ b/src/persist.js
@@ -729,7 +729,7 @@ Persist = (function() {
             key = l.key(i);
             keys = key.split('>');
             if ((keys.length == 2) && (keys[0] == this.name)) {
-              fn.call(scope || this,key, l.getItem(key));
+              fn.call(scope || this,keys[1], l.getItem(key));
             }
           }
         }


### PR DESCRIPTION
The key names during iteration were including the Store namespace during iteration and could not be used for later access (such as through calls to .remove) before removing the namespace.
